### PR TITLE
Debounce search input

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,7 @@
+var loadRemoteResource = require('../reader/load-remote-resource');
+
+function fetchFrom(callback) {
+  return callback || loadRemoteResource;
+}
+
+module.exports = fetchFrom;


### PR DESCRIPTION
Add a 300ms debounce to the search input to reduce unnecessary API requests and avoid flicker while typing. Implements a useDebounce hook in the Search component and updates related tests to account for the delay.